### PR TITLE
Add from-scratch neural network for stroke prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# deep-learning-assignment-csa
+# Stroke Prediction Neural Network Assignment
+
+This project contains a from-scratch implementation of a small feedforward neural network for
+predicting strokes using the Kaggle healthcare dataset. The code is organised into reusable
+modules that implement activation functions, loss, forward and backward passes, gradient descent
+variants, and experiment tooling required by the assignment brief.
+
+## Project structure
+
+```
+src/
+├── activations.py     # Activation functions (sigmoid, ReLU, tanh) and derivatives
+├── data_utils.py      # Dataset loading, preprocessing, and 80/20 train-test split
+├── experiments.py     # Script to run experiments across activations & GD variants
+├── losses.py          # Binary cross-entropy loss and derivative
+├── metrics.py         # Accuracy metric for evaluation
+├── network.py         # Fully-connected network with forward & backward passes
+└── trainer.py         # Training loop supporting batch, stochastic & minibatch GD
+```
+
+## Prerequisites
+
+Install the required Python packages (NumPy, pandas, and scikit-learn):
+
+```bash
+pip install numpy pandas scikit-learn
+```
+
+Download the dataset from Kaggle and place it at `data/healthcare-dataset-stroke-data.csv`:
+
+```bash
+mkdir -p data
+# Copy the downloaded CSV into the data/ directory
+```
+
+## Running experiments
+
+Execute the experiment script to compare activation functions and gradient descent variants:
+
+```bash
+python -m src.experiments --data data/healthcare-dataset-stroke-data.csv --epochs 100 --hidden 64 --lr 0.01 --batch-size 32
+```
+
+The script prints a table summarising the training and test metrics for each combination of
+activation function (`sigmoid`, `relu`, `tanh`) and gradient descent variant (`batch`, `stochastic`,
+`minibatch`). Adjust the hyperparameters via the command-line flags as needed.
+
+## Custom usage
+
+The building blocks can be combined for other experiments. For instance, you can instantiate the
+`FullyConnectedNetwork` and `Trainer` classes directly to explore custom network depths, learning
+rates, or evaluation strategies.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,11 @@
+"""Stroke prediction neural network package."""
+
+__all__ = [
+    "activations",
+    "data_utils",
+    "experiments",
+    "losses",
+    "metrics",
+    "network",
+    "trainer",
+]

--- a/src/activations.py
+++ b/src/activations.py
@@ -1,0 +1,55 @@
+"""Activation functions and their derivatives for neural network training."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class ActivationFunction:
+    """Container for an activation function and its derivative."""
+
+    def __init__(self, func, derivative, name: str):
+        self.func = func
+        self.derivative = derivative
+        self.name = name
+
+    def __call__(self, x: np.ndarray) -> np.ndarray:
+        return self.func(x)
+
+    def grad(self, x: np.ndarray) -> np.ndarray:
+        return self.derivative(x)
+
+
+sigmoid = ActivationFunction(
+    func=lambda x: 1.0 / (1.0 + np.exp(-x)),
+    derivative=lambda x: sigmoid.func(x) * (1 - sigmoid.func(x)),
+    name="sigmoid",
+)
+
+relu = ActivationFunction(
+    func=lambda x: np.maximum(0.0, x),
+    derivative=lambda x: (x > 0).astype(float),
+    name="relu",
+)
+
+tanh = ActivationFunction(
+    func=np.tanh,
+    derivative=lambda x: 1.0 - np.tanh(x) ** 2,
+    name="tanh",
+)
+
+
+ACTIVATIONS = {
+    "sigmoid": sigmoid,
+    "relu": relu,
+    "tanh": tanh,
+}
+
+
+def get_activation(name: str) -> ActivationFunction:
+    """Return an :class:`ActivationFunction` by name."""
+
+    lowered = name.lower()
+    if lowered not in ACTIVATIONS:
+        raise KeyError(f"Unknown activation '{name}'. Available: {list(ACTIVATIONS)}")
+    return ACTIVATIONS[lowered]

--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -1,0 +1,53 @@
+"""Utility helpers for loading and preprocessing the stroke dataset."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import MinMaxScaler
+
+
+CATEGORICAL_COLUMNS = ["gender", "ever_married", "work_type", "Residence_type", "smoking_status"]
+TARGET_COLUMN = "stroke"
+
+
+def load_dataset(csv_path: str | Path) -> pd.DataFrame:
+    path = Path(csv_path)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Dataset not found at {path}. Download 'healthcare-dataset-stroke-data.csv' "
+            "from Kaggle and place it at this location."
+        )
+    return pd.read_csv(path)
+
+
+def preprocess_dataframe(df: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray, list[str]]:
+    df = df.copy()
+    df = df.dropna()
+    features = df.drop(columns=[TARGET_COLUMN])
+    target = df[TARGET_COLUMN].astype(int).to_numpy().reshape(-1, 1)
+    features = pd.get_dummies(features, columns=CATEGORICAL_COLUMNS, drop_first=True)
+    scaler = MinMaxScaler()
+    scaled_features = scaler.fit_transform(features)
+    return scaled_features.astype(float), target.astype(float), list(features.columns)
+
+
+def train_test_split_dataset(
+    csv_path: str | Path,
+    test_size: float = 0.2,
+    random_state: int = 42,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, list[str]]:
+    df = load_dataset(csv_path)
+    X, y, feature_names = preprocess_dataframe(df)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X,
+        y,
+        test_size=test_size,
+        random_state=random_state,
+        stratify=y,
+    )
+    return X_train, X_test, y_train, y_test, feature_names

--- a/src/experiments.py
+++ b/src/experiments.py
@@ -1,0 +1,84 @@
+"""Run experiments comparing activation functions and gradient descent variants."""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+
+from .activations import ACTIVATIONS
+from .data_utils import train_test_split_dataset
+from .losses import binary_cross_entropy
+from .network import FullyConnectedNetwork
+from .trainer import Trainer
+
+
+def run_experiments(
+    dataset_path: str | Path,
+    hidden_neurons: int = 32,
+    epochs: int = 50,
+    learning_rate: float = 0.01,
+    batch_size: int = 32,
+    seed: int = 42,
+) -> pd.DataFrame:
+    X_train, X_test, y_train, y_test, _ = train_test_split_dataset(dataset_path)
+    input_size = X_train.shape[1]
+    results: List[Dict[str, float | str]] = []
+
+    for activation_name, gd_variant in itertools.product(ACTIVATIONS.keys(), ["batch", "stochastic", "minibatch"]):
+        network = FullyConnectedNetwork(
+            layer_sizes=[input_size, hidden_neurons, 1],
+            hidden_activation=activation_name,
+            output_activation="sigmoid",
+            weight_scale=0.1,
+            seed=seed,
+        )
+        trainer = Trainer(
+            network=network,
+            loss=binary_cross_entropy,
+            learning_rate=learning_rate,
+            batch_size=batch_size,
+            max_epochs=epochs,
+            gradient_descent=gd_variant,
+        )
+        history = trainer.fit(X_train, y_train)
+        metrics = trainer.evaluate(X_test, y_test)
+        results.append(
+            {
+                "activation": activation_name,
+                "gd_variant": gd_variant,
+                "final_train_loss": history.losses[-1],
+                "final_train_accuracy": history.accuracies[-1],
+                "test_loss": metrics["loss"],
+                "test_accuracy": metrics["accuracy"],
+            }
+        )
+    return pd.DataFrame(results)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Stroke prediction neural network experiments")
+    parser.add_argument(
+        "--data",
+        type=str,
+        default="data/healthcare-dataset-stroke-data.csv",
+        help="Path to the stroke dataset CSV file.",
+    )
+    parser.add_argument("--hidden", type=int, default=32, help="Number of neurons in the hidden layer.")
+    parser.add_argument("--epochs", type=int, default=50, help="Number of training epochs.")
+    parser.add_argument("--lr", type=float, default=0.01, help="Learning rate for gradient descent.")
+    parser.add_argument("--batch-size", type=int, default=32, help="Minibatch size.")
+    args = parser.parse_args()
+
+    df_results = run_experiments(
+        dataset_path=args.data,
+        hidden_neurons=args.hidden,
+        epochs=args.epochs,
+        learning_rate=args.lr,
+        batch_size=args.batch_size,
+    )
+    print(df_results.to_string(index=False))

--- a/src/losses.py
+++ b/src/losses.py
@@ -1,0 +1,47 @@
+"""Loss functions for supervised learning."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+class LossFunction:
+    """Container for a loss function and its derivative."""
+
+    def __init__(self, func, derivative, name: str):
+        self.func = func
+        self.derivative = derivative
+        self.name = name
+
+    def __call__(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        return float(self.func(y_true, y_pred))
+
+    def grad(self, y_true: np.ndarray, y_pred: np.ndarray) -> np.ndarray:
+        return self.derivative(y_true, y_pred)
+
+
+_DEF_EPS = 1e-12
+
+
+def _clip(y_pred: np.ndarray) -> np.ndarray:
+    return np.clip(y_pred, _DEF_EPS, 1 - _DEF_EPS)
+
+
+binary_cross_entropy = LossFunction(
+    func=lambda y_true, y_pred: -np.mean(
+        y_true * np.log(_clip(y_pred)) + (1 - y_true) * np.log(_clip(1 - y_pred))
+    ),
+    derivative=lambda y_true, y_pred: (-(y_true / _clip(y_pred)) + (1 - y_true) / _clip(1 - y_pred)) / y_true.shape[0],
+    name="binary_cross_entropy",
+)
+
+LOSSES = {
+    "binary_cross_entropy": binary_cross_entropy,
+}
+
+
+def get_loss(name: str) -> LossFunction:
+    lowered = name.lower()
+    if lowered not in LOSSES:
+        raise KeyError(f"Unknown loss '{name}'. Available: {list(LOSSES)}")
+    return LOSSES[lowered]

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,10 @@
+"""Evaluation metrics for model assessment."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def accuracy_score(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    predictions = (y_pred >= 0.5).astype(int)
+    return float(np.mean(predictions == y_true))

--- a/src/network.py
+++ b/src/network.py
@@ -1,0 +1,85 @@
+"""Implementation of a simple fully-connected neural network from scratch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+import numpy as np
+
+from .activations import ActivationFunction, get_activation
+
+
+@dataclass
+class Layer:
+    weights: np.ndarray
+    biases: np.ndarray
+    activation: ActivationFunction
+
+    def forward(self, x: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        z = x @ self.weights + self.biases
+        a = self.activation(z)
+        return z, a
+
+
+class FullyConnectedNetwork:
+    """A minimal dense neural network with one or more hidden layers."""
+
+    def __init__(
+        self,
+        layer_sizes: Sequence[int],
+        hidden_activation: str = "relu",
+        output_activation: str = "sigmoid",
+        weight_scale: float = 0.01,
+        seed: int | None = None,
+    ) -> None:
+        if len(layer_sizes) < 2:
+            raise ValueError("layer_sizes must specify at least input and output size")
+        self.rng = np.random.default_rng(seed)
+        self.layers: List[Layer] = []
+        for idx in range(len(layer_sizes) - 1):
+            fan_in, fan_out = layer_sizes[idx], layer_sizes[idx + 1]
+            activation_name = output_activation if idx == len(layer_sizes) - 2 else hidden_activation
+            activation = get_activation(activation_name)
+            limit = weight_scale
+            weights = self.rng.normal(0.0, limit, size=(fan_in, fan_out))
+            biases = np.zeros(fan_out)
+            self.layers.append(Layer(weights=weights, biases=biases, activation=activation))
+
+    def forward(self, x: np.ndarray) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+        activations = [x]
+        zs = []
+        for layer in self.layers:
+            z, a = layer.forward(activations[-1])
+            zs.append(z)
+            activations.append(a)
+        return zs, activations
+
+    def predict(self, x: np.ndarray) -> np.ndarray:
+        _, activations = self.forward(x)
+        return activations[-1]
+
+    def backward(
+        self,
+        loss_grad: np.ndarray,
+        zs: Sequence[np.ndarray],
+        activations: Sequence[np.ndarray],
+    ) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+        grad_weights: List[np.ndarray] = [np.zeros_like(layer.weights) for layer in self.layers]
+        grad_biases: List[np.ndarray] = [np.zeros_like(layer.biases) for layer in self.layers]
+
+        delta = loss_grad
+        for idx in reversed(range(len(self.layers))):
+            z = zs[idx]
+            activation_grad = self.layers[idx].activation.grad(z)
+            delta = delta * activation_grad
+            grad_weights[idx] = activations[idx].T @ delta
+            grad_biases[idx] = np.sum(delta, axis=0)
+            if idx > 0:
+                delta = delta @ self.layers[idx].weights.T
+        return grad_weights, grad_biases
+
+    def update_parameters(self, grad_weights: Sequence[np.ndarray], grad_biases: Sequence[np.ndarray], lr: float) -> None:
+        for layer, dW, dB in zip(self.layers, grad_weights, grad_biases):
+            layer.weights -= lr * dW
+            layer.biases -= lr * dB

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -1,0 +1,86 @@
+"""Training utilities implementing various gradient descent variants."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+import numpy as np
+
+from .losses import LossFunction
+from .metrics import accuracy_score
+from .network import FullyConnectedNetwork
+
+
+@dataclass
+class TrainingHistory:
+    losses: List[float]
+    accuracies: List[float]
+
+
+class Trainer:
+    def __init__(
+        self,
+        network: FullyConnectedNetwork,
+        loss: LossFunction,
+        learning_rate: float = 0.01,
+        batch_size: int = 32,
+        max_epochs: int = 100,
+        gradient_descent: str = "batch",
+        shuffle: bool = True,
+    ) -> None:
+        self.network = network
+        self.loss = loss
+        self.learning_rate = learning_rate
+        self.batch_size = batch_size
+        self.max_epochs = max_epochs
+        self.gradient_descent = gradient_descent
+        self.shuffle = shuffle
+
+    def _iter_batches(self, X: np.ndarray, y: np.ndarray) -> Iterable[tuple[np.ndarray, np.ndarray]]:
+        n_samples = X.shape[0]
+        indices = np.arange(n_samples)
+        if self.shuffle:
+            np.random.shuffle(indices)
+        if self.gradient_descent == "batch":
+            yield X[indices], y[indices]
+        elif self.gradient_descent == "stochastic":
+            for idx in indices:
+                yield X[idx : idx + 1], y[idx : idx + 1]
+        elif self.gradient_descent == "minibatch":
+            for start in range(0, n_samples, self.batch_size):
+                end = min(start + self.batch_size, n_samples)
+                batch_idx = indices[start:end]
+                yield X[batch_idx], y[batch_idx]
+        else:
+            raise ValueError(
+                "gradient_descent must be one of {'batch', 'stochastic', 'minibatch'}"
+            )
+
+    def fit(self, X: np.ndarray, y: np.ndarray, X_val: np.ndarray | None = None, y_val: np.ndarray | None = None) -> TrainingHistory:
+        losses: List[float] = []
+        accuracies: List[float] = []
+        for epoch in range(self.max_epochs):
+            for X_batch, y_batch in self._iter_batches(X, y):
+                zs, activations = self.network.forward(X_batch)
+                y_pred = activations[-1]
+                loss_grad = self.loss.grad(y_batch, y_pred)
+                grad_weights, grad_biases = self.network.backward(loss_grad, zs, activations)
+                self.network.update_parameters(grad_weights, grad_biases, self.learning_rate)
+            eval_X = X if X_val is None else X_val
+            eval_y = y if y_val is None else y_val
+            _, activations_eval = self.network.forward(eval_X)
+            predictions = activations_eval[-1]
+            loss_value = self.loss(eval_y, predictions)
+            acc_value = accuracy_score(eval_y, predictions)
+            losses.append(loss_value)
+            accuracies.append(acc_value)
+        return TrainingHistory(losses=losses, accuracies=accuracies)
+
+    def evaluate(self, X: np.ndarray, y: np.ndarray) -> Dict[str, float]:
+        _, activations = self.network.forward(X)
+        predictions = activations[-1]
+        return {
+            "loss": self.loss(y, predictions),
+            "accuracy": accuracy_score(y, predictions),
+        }


### PR DESCRIPTION
## Summary
- add reusable modules implementing activation functions, loss, data prep, and evaluation utilities
- implement a fully connected network with manual forward/backward passes and gradient descent variants
- provide an experiment runner and documentation describing how to execute comparisons on the stroke dataset

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dba73929288330a8695730d9142ec9